### PR TITLE
Fix local client

### DIFF
--- a/qiskit_ibm_experiment/client/local_client.py
+++ b/qiskit_ibm_experiment/client/local_client.py
@@ -817,4 +817,7 @@ class LocalExperimentClient:
             return yaml.safe_load(self._files[experiment_id][file_name])
         elif file_name.endswith(".json"):
             return json.loads(self._files[experiment_id][file_name], cls=json_decoder)
-        return self._files[experiment_id][file_name].read()
+        file = self._files[experiment_id][file_name]
+        data = file.read()
+        file.seek(0) # so next time `file.read()` will return the whole file again
+        return data

--- a/qiskit_ibm_experiment/client/local_client.py
+++ b/qiskit_ibm_experiment/client/local_client.py
@@ -819,5 +819,5 @@ class LocalExperimentClient:
             return json.loads(self._files[experiment_id][file_name], cls=json_decoder)
         file = self._files[experiment_id][file_name]
         data = file.read()
-        file.seek(0) # so next time `file.read()` will return the whole file again
+        file.seek(0)  # so next time `file.read()` will return the whole file again
         return data

--- a/qiskit_ibm_experiment/service/ibm_experiment_service.py
+++ b/qiskit_ibm_experiment/service/ibm_experiment_service.py
@@ -1680,7 +1680,7 @@ class IBMExperimentService:
         self,
         experiment_id: str,
         file_name: str,
-        file_data: Union[Dict, str],
+        file_data: Union[Dict, str, bytes],
         json_encoder: Type[json.JSONEncoder] = json.JSONEncoder,
     ):
         """Uploads a data file to the DB
@@ -1688,7 +1688,7 @@ class IBMExperimentService:
         Args:
             experiment_id: The experiment the data file belongs to
             file_name: The expected filename of the data file
-            file_data: The dictionary of data to save, or JSON serialization of it
+            file_data: The data to save, which can be represented as: a dictionary, a JSON serialization, or the file content.
             json_encoder: Custom encoder to use to encode the experiment.
 
         Additional info:

--- a/qiskit_ibm_experiment/service/ibm_experiment_service.py
+++ b/qiskit_ibm_experiment/service/ibm_experiment_service.py
@@ -100,6 +100,7 @@ class IBMExperimentService:
         verify: Optional[bool] = True,
         local: Optional[bool] = False,
         local_save: Optional[bool] = True,
+        local_db_dir: Optional[str] = _DEFAULT_LOCAL_DB_DIR,
         **kwargs,
     ) -> None:
         """IBMExperimentService constructor.
@@ -143,7 +144,7 @@ class IBMExperimentService:
             )
         else:
             self._api_client = LocalExperimentClient(
-                main_dir=self._DEFAULT_LOCAL_DB_DIR, local_save=local_save
+                main_dir=local_db_dir, local_save=local_save
             )
 
     @property
@@ -256,16 +257,17 @@ class IBMExperimentService:
                     name,
                 )
             account = AccountManager.get(name=name)
-        if local:
-            return Account(local=True)
-
-        if token:
-            return Account(
-                token=token,
-                url=url,
-                proxies=proxies,
-                verify=verify_,
-            ).validate()
+        elif local or token:
+            return (
+                Account(local=True)
+                if local
+                else Account(
+                    token=token,
+                    url=url,
+                    proxies=proxies,
+                    verify=verify_,
+                ).validate()
+            )
 
         if account is None:
             account = AccountManager.get()

--- a/qiskit_ibm_experiment/service/ibm_experiment_service.py
+++ b/qiskit_ibm_experiment/service/ibm_experiment_service.py
@@ -1688,7 +1688,8 @@ class IBMExperimentService:
         Args:
             experiment_id: The experiment the data file belongs to
             file_name: The expected filename of the data file
-            file_data: The data to save, which can be represented as: a dictionary, a JSON serialization, or the file content.
+            file_data: The data to save, which can be represented as: a dictionary, a JSON serialization,
+              or the file content.
             json_encoder: Custom encoder to use to encode the experiment.
 
         Additional info:

--- a/releasenotes/notes/custom-local-db-dir-aafa977b9055401b.yaml
+++ b/releasenotes/notes/custom-local-db-dir-aafa977b9055401b.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Add an option to choose a directory for local client.

--- a/test/service/test_local_experiment_client.py
+++ b/test/service/test_local_experiment_client.py
@@ -26,7 +26,7 @@ from qiskit_ibm_experiment.exceptions import (
     IBMExperimentEntryNotFound,
     IBMExperimentEntryExists,
 )
-
+from tempfile import TemporaryDirectory
 
 class TestExperimentLocalClient(IBMTestCase):
     """Test experiment modules."""
@@ -35,8 +35,13 @@ class TestExperimentLocalClient(IBMTestCase):
     def setUpClass(cls):
         """Initial class level setup."""
         super().setUpClass()
-        cls.service = IBMExperimentService(local=True, local_save=False)
+        cls.temp_dir = TemporaryDirectory()
+        cls.service = IBMExperimentService(local=True, local_db_dir=cls.temp_dir.name)
         cls.service.options["prompt_for_delete"] = False
+    
+    @classmethod
+    def tearDownClass(cls):
+        cls.temp_dir.cleanup()
 
     def test_create_experiment(self):
         """Tests creating an experiment"""

--- a/test/service/test_local_experiment_client.py
+++ b/test/service/test_local_experiment_client.py
@@ -17,6 +17,8 @@ import json
 from typing import Optional, Dict, Any
 from datetime import datetime, timedelta
 from test.service.ibm_test_case import IBMTestCase
+from tempfile import mkdtemp
+from shutil import rmtree
 from dateutil import tz
 import yaml
 from qiskit_ibm_experiment import IBMExperimentService
@@ -26,7 +28,7 @@ from qiskit_ibm_experiment.exceptions import (
     IBMExperimentEntryNotFound,
     IBMExperimentEntryExists,
 )
-from tempfile import TemporaryDirectory
+
 
 class TestExperimentLocalClient(IBMTestCase):
     """Test experiment modules."""
@@ -35,13 +37,13 @@ class TestExperimentLocalClient(IBMTestCase):
     def setUpClass(cls):
         """Initial class level setup."""
         super().setUpClass()
-        cls.temp_dir = TemporaryDirectory()
-        cls.service = IBMExperimentService(local=True, local_db_dir=cls.temp_dir.name)
+        cls.temp_path = mkdtemp()
+        cls.service = IBMExperimentService(local=True, local_db_dir=cls.temp_path)
         cls.service.options["prompt_for_delete"] = False
-    
+
     @classmethod
     def tearDownClass(cls):
-        cls.temp_dir.cleanup()
+        rmtree(cls.temp_path)
 
     def test_create_experiment(self):
         """Tests creating an experiment"""


### PR DESCRIPTION
<!--
⚠️ The pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Fixed the file methods of the local client and added an option to choose a custom directory for it.


### Details and comments
Example of initializing a local service with a custom directory:
```python
from qiskit_ibm_experiment import IBMExperimentService
service = IBMExperimentService(local=True, local_db_dir='/home/usr/results')
```

Fixes #
There were problems with loading and saving `.zip` files.
E.g. this code raised the exception: `TypeError: write() argument must be str, not _io.BytesIO`:
```python
from qiskit_experiments.library.characterization import T1
import numpy as np
from qiskit_aer import AerSimulator
backend = AerSimulator()
t1_delays = np.arange(1e-6, 600e-6, 50e-6)
exp = T1(physical_qubits=(0,), delays=t1_delays)
exp_data = exp.run(backend=backend).block_for_results()

from qiskit_ibm_experiment import IBMExperimentService
exp_service = IBMExperimentService(local=True)
exp_data.service = exp_service
exp_data.save() # this line caused the exception (it calls to IBMExperimentService.file_upload() and then to LocalExperimentClient.save()).
```
 - In order to read a zip file, we need to open it in `'rb'` mode.
 - In `LocalExperimentClient.experiment_file_download()`: if we use `io.BytesIO` and read the data, we need to use `file.seek(0)` so next time we read the data, it will start reading from the beginninng.

